### PR TITLE
Make default radosgw attributes same as those expected in recipe

### DIFF
--- a/attributes/radosgw.rb
+++ b/attributes/radosgw.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 default["ceph"]["radosgw"]["api_fqdn"] = "localhost"
-default["ceph"]["radosgw"]["admin-email"] = "admin@example.com"
+default["ceph"]["radosgw"]["admin_email"] = "admin@example.com"
 default["ceph"]["radosgw"]["rgw_addr"] = "*:80"
 


### PR DESCRIPTION
I was testing the cookbooks and didn't actually set anything at which point chef-client crashed. The reason was that the default attributes keys were different from those expected in recipe/template for radosgw.
