### PR TITLE
Allow for failures, added umount in case node.save fails

### DIFF
--- a/recipes/bootstrap_osd.rb
+++ b/recipes/bootstrap_osd.rb
@@ -64,18 +64,15 @@ else
         if node["crowbar"]["disks"][disk]["usage"] == "Storage" and use == true
           puts "Disk: #{disk} should be used for ceph!"
 
-          system 'ceph-disk-prepare', \
-            "/dev/#{disk}"
-          raise 'ceph-disk-prepare failed' unless $?.exitstatus == 0
-
-          system 'udevadm', \
-            "trigger", \
-            "--subsystem-match=block", \
-            "--action=add"
-          raise 'udevadm trigger failed' unless $?.exitstatus == 0
+          if system "df /dev/#{disk}1"
+            system "umount /dev/#{disk}1"
+          end
+          system "ceph-disk-prepare /dev/#{disk}"
+          system "udevadm trigger --subsystem-match=block --action=add"
 
           node["crowbar"]["disks"][disk]["usage"] = "ceph-osd"
           node.save
+          puts "#{disk} is being set to ceph-osd!"
         end
       end
     end


### PR DESCRIPTION
I'm allowing failures to happen and the code to continue execution. Updating the disk usage doesn't always seem to work and so the "select new disks for ceph osd" block will attempt to prepare the same disk more then once. Added a df to check if the disk is mounted, umount if so, then prepare the disk again and update the usage in crowbar. Once disk usage is properly set to ceph-osd it will not run that block of code again.
