### PR TITLE
Update apt repos to be inline with doc changes

### DIFF
--- a/attributes/apt.rb
+++ b/attributes/apt.rb
@@ -1,1 +1,3 @@
 default['ceph']['branch'] = "release" # Can be testing or autobuild
+# Major release version to install. Currently bobtail (most recent) or argonaut.
+default['ceph']['version'] = "bobtail"

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -4,7 +4,7 @@ case node['ceph']['branch']
 when "release"
   apt_repository "ceph-release" do
     repo_name "ceph"
-    uri "http://www.ceph.com/debian/"
+    uri "http://www.ceph.com/debian-#{node['ceph']['version']}/"
     distribution node['lsb']['codename']
     components ["main"]
     key "https://raw.github.com/ceph/ceph/master/keys/release.asc"


### PR DESCRIPTION
Updated apt repo URLs with new information from documentation to support different repos for bobtail and argonaut.

See http://ceph.com/docs/master/install/debian/
