### PR TITLE
Fix recipe compile error when 'public network' is set to Ceph environment

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -81,7 +81,7 @@ def get_mon_addresses()
       mon_ips = mons.map { |node| Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address }
     else
       if node['ceph']['config']['global'] && node['ceph']['config']['global']['public network']
-        mon_ips = mons.map { |node| find_node_ip_in_network(node['ceph']['config']['global']['public network'], node) }
+        mon_ips = mons.map { |nodeish| find_node_ip_in_network(node['ceph']['config']['global']['public network'], nodeish) }
       else
         mon_ips = mons.map { |node| node['ipaddress'] + ":6789" }
       end


### PR DESCRIPTION
Hi,

this patch fixes the following recipe compile error when  'public network' is set to Ceph environment.
"node" block variable overrode global node variable.

<pre>
================================================================================
Recipe Compile Error in /var/cache/chef/cookbooks/ceph/recipes/mon.rb
================================================================================

NoMethodError
-------------
undefined method `[]' for nil:NilClass

Cookbook Trace:
---------------
  /var/cache/chef/cookbooks/ceph/libraries/default.rb:84:in `get_mon_addresses'
  /var/cache/chef/cookbooks/ceph/libraries/default.rb:84:in `map'
  /var/cache/chef/cookbooks/ceph/libraries/default.rb:84:in `get_mon_addresses'
  /var/cache/chef/cookbooks/ceph/recipes/conf.rb:4:in `from_file'
  /var/cache/chef/cookbooks/ceph/recipes/mon.rb:20:in `from_file'

Relevant File Content:
----------------------
/var/cache/chef/cookbooks/ceph/libraries/default.rb:

 77:      end
 78:
 79:      mons += get_mon_nodes()
 80:      if is_crowbar?
 81:        mon_ips = mons.map { |node| Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address }
 82:      else
 83:        if node['ceph']['config']['global'] && node['ceph']['config']['global']['public network']
 84>>         mon_ips = mons.map { |node| find_node_ip_in_network(node['ceph']['config']['global']['public network'], node) }
 85:        else
 86:          mon_ips = mons.map { |node| node['ipaddress'] + ":6789" }
 87:        end
 88:      end
 89:    end
 90:    return mon_ips.uniq
 91:  end
 92:
 93:  def get_quorum_members_ips()

</pre>
