### PR TITLE
Ceph packages should not be upgraded automatically by chef

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,7 @@ when "rhel", "fedora"
 end
 
 packages.each do |pkg|
-	package pkg do
-		action :upgrade
-	end
+  package pkg do
+    action :install
+  end
 end


### PR DESCRIPTION
Ceph packages should not be upgraded automatically by chef. It may cause downtime for example when ceph versions are backward incompatible.
