### PR TITLE
Adding the proper ceph repos

### DIFF
--- a/roles/ceph-mds.rb
+++ b/roles/ceph-mds.rb
@@ -1,5 +1,6 @@
 name "ceph-mds"
 description "Ceph Metadata Server"
 run_list(
+        'recipe[ceph::repo]',
         'recipe[ceph::mds]'
 )

--- a/roles/ceph-mon.rb
+++ b/roles/ceph-mon.rb
@@ -1,5 +1,6 @@
 name "ceph-mon"
 description "Ceph Monitor"
 run_list(
+        'recipe[ceph::repo]',
         'recipe[ceph::mon]'
 )

--- a/roles/ceph-osd.rb
+++ b/roles/ceph-osd.rb
@@ -1,5 +1,6 @@
 name "ceph-osd"
 description "Ceph Object Storage Device"
 run_list(
+        'recipe[ceph::repo]',
         'recipe[ceph::osd]'
 )

--- a/roles/ceph-radosgw.rb
+++ b/roles/ceph-radosgw.rb
@@ -1,5 +1,6 @@
 name "ceph-radosgw"
 description "Ceph RADOS Gateway"
 run_list(
+        'recipe[ceph::repo]',
         'recipe[ceph::radosgw]'
 )


### PR DESCRIPTION
The documentation suggests adding the ceph.com repositories, and the recipe exists. Therefore, it's silly to depend on the native distro repo. This change merely includes it.
