### PR TITLE
Fix monitor recipe

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -97,7 +97,7 @@ ruby_block "get osd-bootstrap keyring" do
   block do
     run_out = ""
     while run_out.empty?
-      run_out = Mixlib::ShellOut.new("ceph auth get-key client.bootstrap-osd").run_command.stdout.strip
+      run_out = Mixlib::ShellOut.new("ceph --name mon. --keyring /var/lib/ceph/mon/ceph-#{node['hostname']}/keyring auth get-key client.bootstrap-osd").run_command.stdout.strip
       sleep 2
     end
     node.override['ceph']['bootstrap_osd_key'] = run_out


### PR DESCRIPTION
ceph auth get-key client.bootstrap-osd wasn't the best way and fail if admin keyring wasn't present (default behavior)
