### PR TITLE
Fix ceph-disk-activate when /var/lib/ceph/osd doesn't exists

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -56,6 +56,12 @@ else
     group "root"
     mode "0755"
   end
+  
+  directory "/var/lib/ceph/osd" do
+    owner "root"
+    group "root"
+    mode "0755"
+  end
 
   # TODO cluster name
   cluster = 'ceph'


### PR DESCRIPTION
ceph-disk-activates doesn't create /var/lib/ceph/osd but creates /var/lib/ceph/osd/{cluster-name}-{osd-id}
