### PR TITLE
Change osd device status check and provide log info

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -106,7 +106,7 @@ else
     #  - The --dmcrypt option will be available starting w/ Cuttlefish
     unless node["ceph"]["osd_devices"].nil?
       node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
-       if !osd_device["status"].nil?
+        if !osd_device["status"].nil?
           Log.info("osd: osd_device #{osd_device} has already been setup.")
           next
         end


### PR DESCRIPTION
The previous status check didn't work for me, so I've adjusted it and added a log message so that you can see whether it's being skipped.
