### PR TITLE
Move the ownership of /etc/ceph/ from radosgw.rb to conf.rb

### DIFF
--- a/recipes/conf.rb
+++ b/recipes/conf.rb
@@ -8,6 +8,13 @@ if node['roles'].include? 'ceph-radosgw'
   is_rgw = true
 end
 
+directory "/etc/ceph" do
+  owner "root"
+  group "root"
+  mode "0644"
+  action :create
+end
+
 template '/etc/ceph/ceph.conf' do
   source 'ceph.conf.erb'
   variables(

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -48,13 +48,6 @@ unless File.exists?("/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done
     include_recipe "ceph::radosgw_#{node["ceph"]["radosgw"]["webserver_companion"]}"
   end
 
-  directory "/etc/ceph" do
-    owner "root"
-    group "root"
-    mode "0644"
-    action :create
-  end
-
   ruby_block "create rados gateway client key" do
     block do
       keyring = %x[ ceph auth get-or-create client.radosgw.#{node['hostname']} osd 'allow rwx' mon 'allow r' --name mon. --key='#{node["ceph"]["monitor-secret"]}' ]


### PR DESCRIPTION
Since conf.rb is responsible for /etc/ceph/ceph.conf, it should make sure /etc/ceph/ exists first.  All of the other recipes require conf.rb before they do anything.
