### PR TITLE
Use 'roles:' instead of 'role:' in mon search

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -9,11 +9,11 @@ def get_mon_nodes(extra_search=nil)
   if is_crowbar?
     mon_roles = search(:role, 'name:crowbar-* AND run_list:role\[ceph-mon\]')
     if not mon_roles.empty?
-      search_string = mon_roles.map { |role_object| "role:"+role_object.name }.join(' OR ')
+      search_string = mon_roles.map { |role_object| "roles:"+role_object.name }.join(' OR ')
       search_string = "(#{search_string}) AND ceph_config_environment:#{node['ceph']['config']['environment']}"
     end
   else
-    search_string = "role:ceph-mon AND chef_environment:#{node.chef_environment}"
+    search_string = "roles:ceph-mon AND chef_environment:#{node.chef_environment}"
   end
 
   if not extra_search.nil?


### PR DESCRIPTION
Currently, it is not possible to include the `ceph-mon` role in another role (say, `vagrant`). This is due to http://docs.opscode.com/essentials_search.html#roles-in-run-lists.

This patch simply changes the search field to `roles:`, which includes the expanded run list. Everything should work as usual.
