### PR TITLE
Support directories as OSD devices

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -114,8 +114,17 @@ else
         if osd_device["encrypted"] == true
           dmcrypt = "--dmcrypt"
         end
+        create_cmd = "ceph-disk-prepare #{dmcrypt} #{osd_device['device']} #{osd_device['journal']}"
+        if osd_device["type"] == "directory"
+          directory osd_device["device"] do
+            owner "root"
+            group "root"
+            recursive true
+          end
+          create_cmd << " && ceph-disk-activate #{osd_device['device']}"
+        end
         execute "Creating Ceph OSD on #{osd_device['device']}" do
-          command "ceph-disk-prepare #{dmcrypt} #{osd_device['device']} #{osd_device['journal']}"
+          command create_cmd
           action :run
           notifies :create, "ruby_block[save osd_device status]"
         end


### PR DESCRIPTION
Currently, if you give an OSD `:device` a directory (not a block device), the OSD never gets activated because udev cannot pick it up automatically. Also, the directory must already exist, which means that you'll need another recipe just for creating the directory.

This patch adds a new field to `node["ceph"]["osd_devices"][n]`, called "type". When the field is not present, or does not have the value `"directory"`, there is no change in functionality. However, when the value is "directory", two things happen. First, the directory is created, unless it already exists. Then, the `ceph-disk-prepare` command is augmented to include `ceph-disk-activate`, which activates the prepared directory. For disks this is not necessary, as udev will pick up the prepared disk and activate it automatically.

While using the OS disk is usually not recommended, it is very useful for development virtual machines (Vagrant), and also those unfortunate cases where you don't have full control over your instances (to add disks) but would still like to use Ceph.

One additional thing to look out for is that if the file system is ext3 or ext4, `node["ceph"]["config"]["osd"]["filestore xattr use omap"]` must be set to `true`, or the OSDs will fail to activate. However, I believe that this is outside the scope of this cookbook and should be set by the user.
