### PR TITLE
Change roles to role when searching for ceph-mon

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -13,7 +13,7 @@ def get_mon_nodes(extra_search=nil)
       search_string = "(#{search_string}) AND ceph_config_environment:#{node['ceph']['config']['environment']}"
     end
   else
-    search_string = "roles:ceph-mon AND chef_environment:#{node.chef_environment}"
+    search_string = "role:ceph-mon AND chef_environment:#{node.chef_environment}"
   end
 
   if not extra_search.nil?


### PR DESCRIPTION
roles searches the expanded run list. This isn't
available for other nodes to search until the
run completes. This means you must run chef on
one mon at a time and your initial mons can only
be one mon. If more than one mon is used the
chef run get stuck trying to get the bootstrap
osd keyring.
