### PR TITLE
radosgw fails to start since necessary pools don't exist and can't be created

### DIFF
--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -50,7 +50,7 @@ unless File.exists?("/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done
 
   ruby_block "create rados gateway client key" do
     block do
-      keyring = %x[ ceph auth get-or-create client.radosgw.#{node['hostname']} osd 'allow rwx' mon 'allow r' --name mon. --key='#{node["ceph"]["monitor-secret"]}' ]
+      keyring = %x[ ceph auth get-or-create client.radosgw.#{node['hostname']} osd 'allow rwx' mon 'allow rw' --name mon. --key='#{node["ceph"]["monitor-secret"]}' ]
       keyfile = File.new("/etc/ceph/ceph.client.radosgw.#{node['hostname']}.keyring", "w")
       keyfile.puts(keyring)
       keyfile.close


### PR DESCRIPTION
Hi All,

Deploying radosgw with this cookbook doesn't properly provision radosgw in that required pools can't be created and this causes radosgw itself to refuse to start:

```
2013-10-31 11:46:59.262369 7f992d769780  0 ceph version 0.72-rc1 (e11c9756af0dd627affb605ae2656c2581a98c8a), process radosgw, pid 6583
2013-10-31 11:46:59.262400 7f992d769780 -1 WARNING: libcurl doesn't support curl_multi_wait()
2013-10-31 11:46:59.262411 7f992d769780 -1 WARNING: cross zone / region transfer performance may be affected
2013-10-31 11:46:59.278099 7f992d769780  0 couldn't find old data placement pools config, setting up new ones for the zone
2013-10-31 11:46:59.278704 7f992d769780 -1 error storing zone params: (1) Operation not permitted
2013-10-31 11:46:59.279504 7f992d769780 -1 Couldn't init storage provider (RADOS)
```

I know there was some discussion about this in https://github.com/ceph/ceph-cookbooks/pull/33, however I don't feel having radosgw create the pools to be a problem as a) you can set an attribute for ceph config option `osd_pool_default_pg_num` or alternatively increase the `pg_num`/`pgp_num` manually later if the default is not appropriate for your environment.

What do you all think?

Thanks!

-Matt
