### PR TITLE
Re-running chef-client with node running ceph::osd fails to `each_with_index` being the wrong method.

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -114,7 +114,7 @@ else
     unless node["ceph"]["osd_devices"].nil?
       devices = node["ceph"]["osd_devices"]
       unless devices.is_a? Hash
-        devices = Hash[(0..devices.size).zip devices]
+        devices = Hash[(0...devices.size).zip devices]
       end
        
       devices.each do |index,osd_device|


### PR DESCRIPTION
Essentially, `each_with_index` returns an Array with the index, then the value... so [0, {"status":"deployed"}]. That is not the right behavior.

Here is the symptom in a chef run:

``` quote
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/ceph/recipes/osd.rb
================================================================================


TypeError
---------
can't convert String into Integer


Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/ceph/recipes/osd.rb:116:in `[]'
  /var/chef/cache/cookbooks/ceph/recipes/osd.rb:116:in `block in from_file'
  /var/chef/cache/cookbooks/ceph/recipes/osd.rb:115:in `each'
  /var/chef/cache/cookbooks/ceph/recipes/osd.rb:115:in `each_with_index'
  /var/chef/cache/cookbooks/ceph/recipes/osd.rb:115:in `from_file'


Relevant File Content:
----------------------
/var/chef/cache/cookbooks/ceph/recipes/osd.rb:

109:      # IMPORTANT:
110:      #  - Always use the default path for OSD (i.e. /var/lib/ceph/
111:      # osd/$cluster-$id)
112:      #  - $cluster should always be ceph
113:      #  - The --dmcrypt option will be available starting w/ Cuttlefish
114:      unless node["ceph"]["osd_devices"].nil?
115:        node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
116>>         if !osd_device["status"].nil?
117:            Log.info("osd: osd_device #{osd_device} has already been setup.")
118:            next
119:          end
120:          dmcrypt = ""
121:          if osd_device["encrypted"] == true
122:            dmcrypt = "--dmcrypt"
123:          end
124:          create_cmd = "ceph-disk-prepare #{dmcrypt} #{osd_device['device']} #{osd_device['journal']}"
125:          if osd_device["type"] == "directory"
```

When inspecting the output with chef-shell:

```
chef:recipe > node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
chef:recipe > puts osd_device.class
chef:recipe ?> end
Array
Array
 => {"0"=>{"status"=>"deployed"}, "1"=>{"status"=>"deployed"}}
chef:recipe > node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
chef:recipe > puts osd_device[0]
chef:recipe ?> end
0
1
 => {"0"=>{"status"=>"deployed"}, "1"=>{"status"=>"deployed"}}
chef:recipe > node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
chef:recipe > puts osd_device[1]
chef:recipe ?> end
{"status"=>"deployed"}
{"status"=>"deployed"}
 => {"0"=>{"status"=>"deployed"}, "1"=>{"status"=>"deployed"}}
chef:recipe > node["ceph"]["osd_devices"].each_with_index do |osd_device,index|
chef:recipe > puts osd_device[1]
chef:recipe ?> puts "index - #{index}"
chef:recipe ?> end
{"status"=>"deployed"}
index - 0
{"status"=>"deployed"}
index - 1
 => {"0"=>{"status"=>"deployed"}, "1"=>{"status"=>"deployed"}}
```
