### PR TITLE
fix location of ceph-release rpm for rhel platform_family

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -15,7 +15,7 @@ when "debian"
   default['ceph']['debian']['dev']['repository_key'] = "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"
 when "rhel"
   #Redhat/CentOS default repositories
-  default['ceph']['rhel']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/el6/x86_64/ceph-release-1-0.el6.noarch.rpm"
+  default['ceph']['rhel']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/el6/noarch/ceph-release-1-0.el6.noarch.rpm"
   default['ceph']['rhel']['testing']['repository'] = "#{node['ceph']['repo_url']}/rpm-testing/el6/x86_64/ceph-release-1-0.el6.noarch.rpm"
   default['ceph']['rhel']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-rpm-centos6-x86_64-basic/ref/#{node['ceph']['version']}/x86_64/"
   default['ceph']['rhel']['dev']['repository_key'] = "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"


### PR DESCRIPTION
when using the cookbooks to install onto a rhel platform_family (in my case centos), the ceph-release rpm location was wrong.  Instead of eg:

```
http://ceph.com/rpm-dumpling/el6/x86_64/ceph-release-1-0.el6.noarch.rpm
```

it should be

```
http://ceph.com/rpm-dumpling/el6/noarch/ceph-release-1-0.el6.noarch.rpm
```

fixes: https://github.com/ceph/ceph-cookbooks/issues/77
