### PR TITLE
Allow nss db files to be created for keystone integration

### DIFF
--- a/attributes/radosgw.rb
+++ b/attributes/radosgw.rb
@@ -21,6 +21,7 @@ default["ceph"]["radosgw"]["admin_email"] = "admin@example.com"
 default["ceph"]["radosgw"]["rgw_addr"] = "*:80"
 default["ceph"]["radosgw"]["rgw_port"] = false
 default["ceph"]["radosgw"]["webserver_companion"] = "apache2" #can be false
+default["ceph"]["radosgw"]["process_owner"] = node['apache']['user']
 default['ceph']["radosgw"]['use_apache_fork'] = true
 case node['platform']
 when 'ubuntu'


### PR DESCRIPTION
Specify keystone signing/ca.pem file and have radosgw recipe automatically convert these.
Only run if both ca/signing_cert and nss db path are specified.
