### PR TITLE
Properly accesses the node's dmcrypt attribute

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -38,7 +38,7 @@ package 'gdisk' do
   action :upgrade
 end
 
-if !search(:node,"hostname:#{node['hostname']} AND dmcrypt:true").empty?
+if node[:dmcrypt]
     package 'cryptsetup' do
       action :upgrade
     end


### PR DESCRIPTION
Doing a direct node attribute access is much clearer than doing a search. Additionally, the search will not find the result until after the node is saved at the end of the first run. This will cause cryptsetup to not be installed, which will cause the later OSD device setups to fail.
