### PR TITLE
Adds configuration to allow MDS to run

### DIFF
--- a/attributes/mds.rb
+++ b/attributes/mds.rb
@@ -1,0 +1,6 @@
+case node['platform']
+when 'ubuntu'
+  default["ceph"]["mds"]["init_style"] = "upstart"
+else
+  default["ceph"]["mds"]["init_style"] = "sysvinit"
+end

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -16,5 +16,57 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-		        
+
 include_recipe "ceph::default"
+include_recipe "ceph::conf"
+
+cluster = 'ceph'
+
+directory "/var/lib/ceph/mds/#{cluster}-#{node["hostname"]}" do
+  owner "root"
+  group "root"
+  mode 00755
+  recursive true
+  action :create
+end
+
+ruby_block "create mds client key" do
+  block do
+    keyring = %x[ ceph auth get-or-create mds.#{node['hostname']} osd 'allow *' mon 'allow rwx' --name mon. --key='#{node["ceph"]["monitor-secret"]}' ]
+    keyfile = File.new("/var/lib/ceph/mds/#{cluster}-#{node['hostname']}/keyring", "w")
+    keyfile.puts(keyring)
+    keyfile.close
+  end
+end
+
+file "/var/lib/ceph/mds/#{cluster}-#{node["hostname"]}/done" do
+  owner "root"
+  group "root"
+  mode 00644
+end
+
+service_type = node["ceph"]["osd"]["init_style"]
+
+case service_type
+when "upstart"
+  filename = "upstart"
+else
+  filename = "sysvinit"
+end
+file "/var/lib/ceph/mds/#{cluster}-#{node["hostname"]}/#{filename}" do
+  owner "root"
+  group "root"
+  mode 00644
+end
+
+service "ceph_mds" do
+  case service_type
+  when "upstart"
+    service_name "ceph-mds-all-starter"
+    provider Chef::Provider::Service::Upstart
+  else
+    service_name "ceph"
+  end
+  action [ :enable, :start ]
+  supports :restart => true
+end


### PR DESCRIPTION
The original ceph::mds recipe did not start the MDS daemon. This patch adds enough functionality to get MDS running.
