### PR TITLE
Fixes the case where no mon IPs can be found in the public subnet

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -61,6 +61,7 @@ def find_node_ip_in_network(network, nodeish=nil)
       end
     end
   end
+  nil
 end
 
 def get_mon_addresses()
@@ -88,6 +89,7 @@ def get_mon_addresses()
       end
     end
   end
+  mon_ips = mon_ips.reject{|m|m.nil?}
   return mon_ips.uniq
 end
 


### PR DESCRIPTION
When searching through mons for an IP in the public subnet, if no routes
match the public network, it returns the mon's entire network object
which then gets outputted to the ceph.conf file and generally breaks things.
This prevents that occurrence.
