### PR TITLE
Make radosgw log match logrotate

### DIFF
--- a/templates/default/ceph.conf.erb
+++ b/templates/default/ceph.conf.erb
@@ -34,7 +34,7 @@
   host = <%= node['hostname'] %>
   rgw socket path = /var/run/ceph/radosgw.<%= node['hostname'] %>
   keyring = /etc/ceph/ceph.client.radosgw.<%= node['hostname'] %>.keyring
-  log file = /var/log/radosgw//radosgw.log
+  log file = /var/log/radosgw/radosgw.log
 <% if (! node['ceph']['config']['rgw'].nil?) -%>
   <% node['ceph']['config']['rgw'].each do |k, v| %>
   <%= k %> = <%= v %>


### PR DESCRIPTION
/etc/logrotate.d/radosgw was rotating /var/log/radosgw/*.log.
/etc/logrotate.d/ceph was rotating /var/log/ceph/*.log, but not notifying radosgw.

Now radosgw will be notified when it's logs are rotated.
