### PR TITLE
apt: use a variable for distribution codename

### DIFF
--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -3,10 +3,16 @@ include_recipe "apt"
 
 branch = node['ceph']['branch']
 
+distribution_codename =
+case node['lsb']['codename']
+when "jessie" then "sid"
+else node['lsb']['codename']
+end
+
 apt_repository "ceph" do
   repo_name "ceph"
   uri node['ceph']['debian'][branch]['repository']
-  distribution node['lsb']['codename'] == "jessie" ? "sid" : node['lsb']['codename']
+  distribution distribution_codename
   components ['main']
   key node['ceph']['debian'][branch]['repository_key']
 end
@@ -14,7 +20,7 @@ end
 apt_repository "ceph-extras" do
   repo_name "ceph-extras"
   uri node['ceph']['debian']['extras']['repository']
-  distribution node['lsb']['codename'] == "jessie" ? "sid" : node['lsb']['codename']
+  distribution distribution_codename
   components ['main']
   key node['ceph']['debian']['extras']['repository_key']
   only_if { node['ceph']['extras_repo'] }
@@ -27,15 +33,15 @@ if node['ceph']['is_radosgw'] \
   when "precise", "oneiric"
     apt_repository "ceph-apache2" do
       repo_name "ceph-apache2"
-      uri "http://gitbuilder.ceph.com/apache2-deb-#{node['lsb']['codename']}-x86_64-basic/ref/master"
-      distribution node['lsb']['codename']
+      uri "http://gitbuilder.ceph.com/apache2-deb-#{distribution_codename}-x86_64-basic/ref/master"
+      distribution distribution_codename
       components ["main"]
       key "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"
     end
     apt_repository "ceph-modfastcgi" do
       repo_name "ceph-modfastcgi"
-      uri "http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-#{node['lsb']['codename']}-x86_64-basic/ref/master"
-      distribution node['lsb']['codename']
+      uri "http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-#{distribution_codename}-x86_64-basic/ref/master"
+      distribution distribution_codename
       components ["main"]
       key "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc"
     end


### PR DESCRIPTION
The use of a variable for the distribution codename simplifies
the recipe, and allows to add exception easily.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
