### PR TITLE
Makes rubocop happy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,5 @@ LineLength:
   Enabled: false
 MethodLength:
   Max: 30
+FileName:
+  Enabled: false

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -46,7 +46,7 @@ end
 def mon_addresses
   mon_ips = []
 
-  if File.exists?("/var/run/ceph/ceph-mon.#{node['hostname']}.asok")
+  if File.exist?("/var/run/ceph/ceph-mon.#{node['hostname']}.asok")
     mon_ips = quorum_members_ips
   else
     mons = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,27 +21,27 @@ packages = []
 
 case node['platform_family']
 when "debian"
-  packages = %w{
-      ceph
-      ceph-common
-  }
+  packages = %w(
+    ceph
+    ceph-common
+  )
 
   if node['ceph']['install_debug']
-    packages_dbg = %w{
+    packages_dbg = %w(
       ceph-dbg
       ceph-common-dbg
-    }
+    )
     packages += packages_dbg
   end
 when "rhel", "fedora"
-  packages = %w{
-      ceph
-  }
+  packages = %w(
+    ceph
+  )
 
   if node['ceph']['install_debug']
-    packages_dbg = %w{
+    packages_dbg = %w(
       ceph-debug
-    }
+    )
     packages += packages_dbg
   end
 end

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -40,7 +40,7 @@ end
 # TODO: cluster name
 cluster = 'ceph'
 
-unless File.exists?("/var/lib/ceph/mon/ceph-#{node["hostname"]}/done")
+unless File.exist?("/var/lib/ceph/mon/ceph-#{node["hostname"]}/done")
   keyring = "#{Chef::Config[:file_cache_path]}/#{cluster}-#{node['hostname']}.mon.keyring"
 
   if node['ceph']['encrypted_data_bags']

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -21,20 +21,20 @@ node.default['ceph']['is_radosgw'] = true
 
 case node['platform_family']
 when "debian"
-  packages = %w{
+  packages = %w(
     radosgw
-  }
+  )
 
   if node['ceph']['install_debug']
-    packages_dbg = %w{
+    packages_dbg = %w(
       radosgw-dbg
-    }
+    )
     packages += packages_dbg
   end
 when "rhel", "fedora", "suse"
-  packages = %w{
+  packages = %w(
     ceph-radosgw
-  }
+  )
 end
 
 packages.each do |pkg|

--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -19,15 +19,15 @@
 
 case node['platform_family']
 when "debian", "suse"
-  packages = %w{
+  packages = %w(
     apache2
     libapache2-mod-fastcgi
-  }
+  )
 when "rhel", "fedora"
-  packages = %w{
+  packages = %w(
     httpd
     mod_fastcgi
-  }
+  )
 end
 
 packages.each do |pkg|
@@ -47,10 +47,10 @@ if node['platform_family'] == "rhel"
   d_owner = d_group = "apache"
 end
 
-%W{ /var/run/ceph
+%W( /var/run/ceph
     /var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}
     /var/lib/apache2/
-}.each do |dir|
+).each do |dir|
   directory dir do
     owner d_owner
     group d_group

--- a/recipes/tgt.rb
+++ b/recipes/tgt.rb
@@ -21,13 +21,13 @@ node.default['ceph']['extras_repo'] = true
 
 case node['platform_family']
 when "debian"
-  packages = %w{
+  packages = %w(
     tgt
-  }
+  )
 when "rhel", "fedora"
-  packages = %w{
+  packages = %w(
     scsi-target-utils
-  }
+  )
 end
 
 packages.each do |pkg|


### PR DESCRIPTION
this commit introduces a few changes to make rubocop happy:
- disable the name checking on filename (didn't wanted to change the
  dashed filenames for backward compat)
- replace %w{} literal notation to %w()
- use File.exist? instead of deprecated File.exists?

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
