### PR TITLE
Puts the radosgw key in the proper location for Ubuntu

### DIFF
--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -53,7 +53,8 @@ if !::File.exists?("/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done"
   ceph_client 'radosgw' do
     caps('mon' => 'allow rw', 'osd' => 'allow rwx')
   end
-  ceph_client 'radosgw' do
+  ceph_client 'radosgw keyring' do
+    keyname "client.radosgw.#{node['hostname']}"
     filename "/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/keyring"
     caps('mon' => 'allow rw', 'osd' => 'allow rwx')
   end


### PR DESCRIPTION
In my Ubuntu, radosgw looks in /var/lib/ceph/radosgw/ceph-radosgw.{hostname}/keyring for the keyring, instead of the expected /etc/ceph/ceph.client.radosgw.{hostname}.keyring. This works around it by putting it in both places.
