### PR TITLE
Allows nodes to specify a ceph environment to search

### DIFF
--- a/attributes/conf.rb
+++ b/attributes/conf.rb
@@ -1,2 +1,3 @@
 default['ceph']['config'] = {}
 default['ceph']['config-sections'] = {}
+default['ceph']['search_environment'] = true

--- a/templates/default/ceph.conf.erb
+++ b/templates/default/ceph.conf.erb
@@ -1,6 +1,8 @@
 [global]
+<% if node['ceph']['is_mon'] -%>
   fsid = <%= node["ceph"]["config"]["fsid"] %>
   mon initial members = <%= node["ceph"]["config"]["mon_initial_members"] %>
+<% end -%>
   mon host = <%= @mon_addresses.sort.join(', ') %>
 <% if (! node['ceph']['config']['global'].nil?) -%>
   <% node['ceph']['config']['global'].sort.each do |k, v| %>


### PR DESCRIPTION
If a server is in a different environment than the ceph mons, but
it still wants to connect to the ceph cluster, it can specify a
node['ceph']['config']['environment'] attribute that matches the
ceph mons' node['ceph']['config']['environment'] attribute.
This will enable the server to find the ceph mon nodes, register
for cephx keyrings, and create a working ceph.conf file
