### PR TITLE
Creates the parent directory for radosgw logs

### DIFF
--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -60,6 +60,13 @@ end
   end
 end
 
+directory '/var/log/radosgw' do
+  owner d_owner
+  group d_group
+  mode '0755'
+  action :create
+end
+
 file '/var/log/radosgw/radosgw.log' do
   owner d_owner
   group d_group


### PR DESCRIPTION
Caused a chef-client crash when it tried to create the empty log file for radosgw, without this directory also being in place.
