### PR TITLE
Moves radosgw logs to /var/log/ceph

### DIFF
--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -60,13 +60,6 @@ end
   end
 end
 
-file '/var/log/radosgw/radosgw.log' do
-  owner d_owner
-  group d_group
-  mode '0644'
-  action :create
-end
-
 include_recipe 'apache2'
 
 apache_module 'fastcgi' do

--- a/templates/default/ceph.conf.erb
+++ b/templates/default/ceph.conf.erb
@@ -34,7 +34,7 @@
   host = <%= node['hostname'] %>
   rgw socket path = /var/run/ceph/radosgw.<%= node['hostname'] %>
   keyring = /etc/ceph/ceph.client.radosgw.<%= node['hostname'] %>.keyring
-  log file = /var/log/radosgw/radosgw.log
+  log file = /var/log/ceph/radosgw.log
 <% if (! node['ceph']['config']['rgw'].nil?) -%>
   <% node['ceph']['config']['rgw'].sort.each do |k, v| %>
   <%= k %> = <%= v %>


### PR DESCRIPTION
It looks like the package logrotate scripts expect them to be there
