### PR TITLE
Make sure radosgw_apache creates the log directory

### DIFF
--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -50,6 +50,7 @@ end
 %W(/var/run/ceph
    /var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}
    /var/lib/apache2/
+   /var/log/radosgw/
 ).each do |dir|
   directory dir do
     owner d_owner


### PR DESCRIPTION
Ceph's logrotate packages look in /var/log/radosgw/ for the RGW logs.  Make sure the directory exists, before we create a file in it.
