### PR TITLE
Tests cephfs and radosgw

### DIFF
--- a/recipes/all_in_one.rb
+++ b/recipes/all_in_one.rb
@@ -1,4 +1,6 @@
 
 include_recipe 'ceph::mon'
 include_recipe 'ceph::osd'
-# include_recipe 'ceph::radosgw'
+include_recipe 'ceph::mds'
+include_recipe 'ceph::cephfs'
+include_recipe 'ceph::radosgw'

--- a/test/integration/aio/bats/ceph-running.bats
+++ b/test/integration/aio/bats/ceph-running.bats
@@ -5,3 +5,15 @@
 @test "ceph is healthy" {
   ceph -s | grep HEALTH_OK
 }
+
+@test "cephfs is mounted" {
+  mount | grep 'type ceph'
+}
+
+@test "radosgw is running" {
+  ps auxwww | grep radosg[w]
+}
+
+@test "apache is running and listening" {
+  netstat -ln | grep -E '^\S+\s+\S+\s+\S+\s+\S+:80\s+'
+}


### PR DESCRIPTION
This PR enables cephfs and radosgw testing in the AIO recipe.
#121 fixes creating the radosgw key by creating a random mon secret
#122 fixes radosgw on Debian

Outstanding problems that I've found:
- CentOS 6 doesn't have cephfs compiled into the kernel. I see that there are packages that probably have it.
- Fedora 18 test-kitchen doesn't have a mod_fastcgi package, where does it come from?
- Ubuntu 14.04 doesn't install the ceph-mds package by default, it is marked as Recommended
