### PR TITLE
Always installs ceph-mds deb package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,12 +24,14 @@ when 'debian'
   packages = %w(
     ceph
     ceph-common
+    ceph-mds
   )
 
   if node['ceph']['install_debug']
     packages_dbg = %w(
       ceph-dbg
       ceph-common-dbg
+      ceph-mds-dbg
     )
     packages += packages_dbg
   end


### PR DESCRIPTION
Before it was relying on being pulled in as a suggested package.
Ubuntu 14.04 doesn't seem to install suggested packages by default.
