### PR TITLE
Fixes mon_addresses when using linux-ha ip aliases

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -4,3 +4,5 @@ include_recipe 'ceph::_common_install'
 node['ceph']['packages'].each do |pck|
   package pck
 end
+
+chef_gem 'netaddr'


### PR DESCRIPTION
linux-ha has an IPaddr and IPaddr2 resource to create HA IP aliases
However, it assigns a broadcast address to this IP
This changes changes mon_addresses to ignore IP addresses that have a netmask of /32
along with the previous check for the existence of broadcast
