### PR TITLE
Explicitly install ceph-fs-common for cephfs

### DIFF
--- a/attributes/cephfs.rb
+++ b/attributes/cephfs.rb
@@ -1,1 +1,10 @@
 default['ceph']['cephfs_mount'] = '/ceph'
+
+case node['platform_family']
+when 'debian'
+  packages = ['ceph-fs-common']
+  packages += debug_packages(packages) if node['ceph']['install_debug']
+  default['ceph']['cephfs']['packages'] = packages
+else
+  default['ceph']['cephfs']['packages'] = []
+end

--- a/recipes/cephfs.rb
+++ b/recipes/cephfs.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 include_recipe 'ceph::_common'
+include_recipe 'ceph::cephfs_install'
 include_recipe 'ceph::conf'
 
 name = 'cephfs'

--- a/recipes/cephfs_install.rb
+++ b/recipes/cephfs_install.rb
@@ -1,0 +1,5 @@
+include_recipe 'ceph::_common_install'
+
+node['ceph']['cephfs']['packages'].each do |pck|
+  package pck
+end


### PR DESCRIPTION
Sometimes, Debian and Ubuntu may be set to not automatically install Suggested packages. The ceph package Suggests ceph-fs-common. This change explicitly installs ceph-fs-common if the user is installing the cephfs recipe, instead of relying on the Suggested status.
