### PR TITLE
Creates the radosgw sentinel directory differently

### DIFF
--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -32,6 +32,10 @@ if !::File.exist?("/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done")
     caps('mon' => 'allow rw', 'osd' => 'allow rwx')
   end
 
+  directory "/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}" do
+    recursive true
+  end
+
   file "/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done" do
     action :create
   end

--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -41,8 +41,6 @@
 #   end
 # end
 
-directory "/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}"
-
 include_recipe 'ceph::_common'
 include_recipe 'ceph::_common_install'
 include_recipe 'ceph::radosgw_apache2_repo'


### PR DESCRIPTION
Instead of relying on the radosgw_apache recipe, just make it in the main radosgw recipe. I ran into this problem when I was testing Centos and Fedora.
