### PR TITLE
Mod-fastcgi installation improvements

### DIFF
--- a/recipes/radosgw_apache2_repo.rb
+++ b/recipes/radosgw_apache2_repo.rb
@@ -15,6 +15,18 @@ if node['ceph']['radosgw']['use_apache_fork'] == true
       components ['main']
       key 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
     end
+  elsif (node.platform_family?('fedora') && [18, 19].include?(node['platform_version'].to_i)) ||
+    (node.platform_family?('rhel') && [6].include?(node['platform_version'].to_i))
+    platform_family = node['platform_family']
+    platform_version = node['platform_version'].to_i
+    yum_repository 'ceph-apache2' do
+      baseurl "http://gitbuilder.ceph.com/apache2-rpm-#{node['platform']}#{platform_version}-x86_64-basic/ref/master"
+      gpgkey node['ceph'][platform_family]['dev']['repository_key']
+    end
+    yum_repository 'ceph-modfastcgi' do
+      baseurl "http://gitbuilder.ceph.com/mod_fastcgi-rpm-#{node['platform']}#{platform_version}-x86_64-basic/ref/master"
+      gpgkey node['ceph'][platform_family]['dev']['repository_key']
+    end
   else
     Log.info("Ceph's Apache and Apache FastCGI forks not available for this distribution")
   end


### PR DESCRIPTION
Some changes to the way that mod_fastcgi on the apache fork is installed.
1. Update the supported list of Deb versions to everything on gitbuilder  (left over from #122)
2. Enables the yum repo for mod_fastcgi and httpd  (fixed my question in #123)
