### PR TITLE
Simplify service definition

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,12 +3,10 @@ default['ceph']['encrypted_data_bags'] = false
 
 default['ceph']['install_repo'] = true
 
-case node['platform']
-when 'ubuntu'
-  default['ceph']['init_style'] = 'upstart'
-else
-  default['ceph']['init_style'] = 'sysvinit'
-end
+default['ceph']['init_style'] = value_for_platform(
+  ['ubuntu'] => 'upstart',
+  'default' => 'sysvinit'
+)
 
 case node['platform_family']
 when 'debian'

--- a/attributes/mds.rb
+++ b/attributes/mds.rb
@@ -1,6 +1,10 @@
 include_attribute 'ceph'
 
-default['ceph']['mds']['init_style'] = node['init_style']
+default['ceph']['mds']['init_style'] = node['ceph']['init_style']
+default['ceph']['mds']['service_name'] = value_for_platform(
+  ['ubuntu'] => 'ceph-mds-all-starter',
+  'default' => 'ceph'
+)
 
 case node['platform_family']
 when 'debian'

--- a/attributes/mon.rb
+++ b/attributes/mon.rb
@@ -1,6 +1,10 @@
 include_attribute 'ceph'
 
 default['ceph']['mon']['init_style'] = node['ceph']['init_style']
+default['ceph']['mon']['service_name'] = value_for_platform(
+  ['ubuntu'] => 'ceph-mon-all-starter',
+  'default' => 'ceph'
+)
 
 default['ceph']['mon']['secret_file'] = '/etc/chef/secrets/ceph_mon'
 

--- a/attributes/osd.rb
+++ b/attributes/osd.rb
@@ -1,6 +1,9 @@
 include_attribute 'ceph'
 
-default['ceph']['osd']['init_style'] = node['ceph']['init_style']
+default['ceph']['osd']['service_name'] = value_for_platform(
+  ['ubuntu'] => 'ceph-osd-all-starter',
+  'default' => 'ceph'
+)
 
 default['ceph']['osd']['secret_file'] = '/etc/chef/secrets/ceph_osd'
 

--- a/attributes/radosgw.rb
+++ b/attributes/radosgw.rb
@@ -25,7 +25,12 @@ default['ceph']['radosgw']['rgw_addr'] = '*:80'
 default['ceph']['radosgw']['rgw_port'] = false
 default['ceph']['radosgw']['webserver_companion'] = 'apache2' # can be false
 default['ceph']['radosgw']['use_apache_fork'] = true
-default['ceph']['radosgw']['init_style'] = node['ceph']['init_style']
+
+default['ceph']['radosgw']['service_name'] = value_for_platform(
+  ['ubuntu'] => 'radosgw-all-starter',
+  ['debian'] => 'radosgw',
+  'default' => 'ceph-radosgw'
+)
 
 case node['platform_family']
 when 'debian'

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -43,28 +43,15 @@ file "/var/lib/ceph/mds/#{cluster}-#{node['hostname']}/done" do
   mode 00644
 end
 
-service_type = node['ceph']['osd']['init_style']
-
-case service_type
-when 'upstart'
-  filename = 'upstart'
-else
-  filename = 'sysvinit'
-end
-file "/var/lib/ceph/mds/#{cluster}-#{node['hostname']}/#{filename}" do
+service_type = node['ceph']['mds']['init_style']
+file "/var/lib/ceph/mds/#{cluster}-#{node['hostname']}/#{service_type}" do
   owner 'root'
   group 'root'
   mode 00644
 end
 
 service 'ceph_mds' do
-  case service_type
-  when 'upstart'
-    service_name 'ceph-mds-all-starter'
-    provider Chef::Provider::Service::Upstart
-  else
-    service_name 'ceph'
-  end
+  service_name node['ceph']['mds']['service_name']
   action [:enable, :start]
   supports :restart => true
 end

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -81,26 +81,18 @@ unless File.exist?("/var/lib/ceph/mon/ceph-#{node['hostname']}/done")
   end
 end
 
-if service_type == 'upstart'
+if node['platform'] == 'ubuntu'
   service 'ceph-mon' do
-    provider Chef::Provider::Service::Upstart
     action :enable
   end
   service 'ceph-mon-all' do
-    provider Chef::Provider::Service::Upstart
     supports :status => true
     action [:enable, :start]
   end
 end
 
 service 'ceph_mon' do
-  case service_type
-  when 'upstart'
-    service_name 'ceph-mon-all-starter'
-    provider Chef::Provider::Service::Upstart
-  else
-    service_name 'ceph'
-  end
+  service_name node['ceph']['mon']['service_name']
   supports :restart => true, :status => true
   action [:enable, :start]
 end

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -44,8 +44,6 @@ package 'cryptsetup' do
   only_if { node['dmcrypt'] }
 end
 
-service_type = node['ceph']['osd']['init_style']
-
 directory '/var/lib/ceph/bootstrap-osd' do
   owner 'root'
   group 'root'
@@ -134,13 +132,7 @@ else
       end
     end
     service 'ceph_osd' do
-      case service_type
-      when 'upstart'
-        service_name 'ceph-osd-all-starter'
-        provider Chef::Provider::Service::Upstart
-      else
-        service_name 'ceph'
-      end
+      service_name node['ceph']['osd']['service_name']
       action [:enable, :start]
       supports :restart => true
     end

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -41,17 +41,7 @@ if !::File.exist?("/var/lib/ceph/radosgw/ceph-radosgw.#{node['hostname']}/done")
   end
 
   service 'radosgw' do
-    case node['ceph']['radosgw']['init_style']
-    when 'upstart'
-      service_name 'radosgw-all-starter'
-      provider Chef::Provider::Service::Upstart
-    else
-      if node['platform'] == 'debian'
-        service_name 'radosgw'
-      else
-        service_name 'ceph-radosgw'
-      end
-    end
+    service_name node['ceph']['radosgw']['service_name']
     supports :restart => true
     action [:enable, :start]
   end


### PR DESCRIPTION
Do not care about init_style this should chef know automatically.

I wonder why the present construct is there, to me this looks like a correct solution. If you agree, I'll also change it for other services, not just osd.
