### PR TITLE
Adds the fsid to ceph-osd hosts

### DIFF
--- a/templates/default/ceph.conf.erb
+++ b/templates/default/ceph.conf.erb
@@ -1,7 +1,9 @@
 [global]
+<% unless node['ceph']['config']['fsid'].nil? -%>
+  fsid = <%= node['ceph']['config']['fsid'] %>
+<% end -%>
 <% if node['ceph']['is_mon'] -%>
-  fsid = <%= node["ceph"]["config"]["fsid"] %>
-  mon initial members = <%= node["ceph"]["config"]["mon_initial_members"] %>
+  mon initial members = <%= node['ceph']['config']['mon_initial_members'] %>
 <% end -%>
   mon host = <%= @mon_addresses.sort.join(', ') %>
 <% if (! node['ceph']['config']['global'].nil?) -%>


### PR DESCRIPTION
This change from #114 was missed, and is necessary for installing any OSDs that aren't colocated with MONs.
