### PR TITLE
Apt-pins the Ceph version to the Ceph repo version

### DIFF
--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -9,6 +9,12 @@ when 'jessie' then 'sid'
 else node['lsb']['codename']
 end
 
+apt_preference 'ceph_repo' do
+  package_name '*'
+  pin 'origin "ceph.com"'
+  pin_priority '1001'
+end
+
 apt_repository 'ceph' do
   repo_name 'ceph'
   uri node['ceph']['debian'][branch]['repository']

--- a/test/integration/aio/bats/version.bats
+++ b/test/integration/aio/bats/version.bats
@@ -1,0 +1,6 @@
+@test "ceph is installed from the official repo" {
+  cephversion=`apt-cache policy ceph | grep -B 1 ceph.com | head -n 1 | sed 's/^[^0-9]\+\([^ ]\+\).*/\1/'`
+  installedversion=`apt-cache policy ceph | grep 'Installed:' | awk '{print $2}'`
+  test "$cephversion" = "$installedversion"
+}
+


### PR DESCRIPTION
Ubuntu 14.04 ships a newer version than this cookbook defaults to.
This pin allows for easy installation of the same Ceph version across multiple Ubuntu versions
