### PR TITLE
Disables Ceph's Apache on Ubuntu 13.10 and 14.04

### DIFF
--- a/recipes/radosgw_apache2_repo.rb
+++ b/recipes/radosgw_apache2_repo.rb
@@ -1,6 +1,6 @@
 if node['ceph']['radosgw']['use_apache_fork'] == true
   if node.platform_family?('debian') &&
-    %w(precise quantal raring saucy trusty squeeze wheezy).include?(node['lsb']['codename'])
+    %w(precise quantal raring squeeze wheezy).include?(node['lsb']['codename'])
     apt_repository 'ceph-apache2' do
       repo_name 'ceph-apache2'
       uri "http://gitbuilder.ceph.com/apache2-deb-#{node['lsb']['codename']}-x86_64-basic/ref/master"


### PR DESCRIPTION
Ubuntu 13.10 and 14.04 use Apache 2.4, while Ceph's Apache fork is only Apache 2.2. I commented in #124 that I'd make this PR to not install Ceph's Apache fork on new Ubuntu, so here it is!
