### PR TITLE
Enables cephx if ceph.config.global exists

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -178,5 +178,6 @@ def use_cephx?(type = nil)
   # CephX is enabled if it's not configured at all, or explicity enabled
   node['ceph']['config'].nil? ||
     node['ceph']['config']['global'].nil? ||
+    node['ceph']['config']['global']["auth #{type} required"].nil? ||
     node['ceph']['config']['global']["auth #{type} required"] == 'cephx'
 end


### PR DESCRIPTION
If you have a ceph.config.global setting, but didn't have a setting
'auth cluster required', the recipe wouldn't try to use cephx.
