### PR TITLE
Updates the mount.fuse.ceph helper for pre-firefly

### DIFF
--- a/recipes/cephfs_install.rb
+++ b/recipes/cephfs_install.rb
@@ -3,3 +3,10 @@ include_recipe 'ceph::_common_install'
 node['ceph']['cephfs']['packages'].each do |pck|
   package pck
 end
+
+# Update the fuse.ceph helper for pre-firefly
+remote_file '/sbin/mount.fuse.ceph' do
+  source 'https://raw.githubusercontent.com/ceph/ceph/master/src/mount.fuse.ceph'
+  only_if { ::File.exist?('/sbin/mount.fuse.ceph') }
+  not_if { ::File.readlines('/sbin/mount.fuse.ceph').grep(/_netdev/).any? }
+end


### PR DESCRIPTION
Firefly has a fixed mount.fuse.ceph helper that strips out the _netdev option before passing the list of options to Fuse. Fuse doesn't like the _netdev option and then refuses to mount if it sees it.
