### PR TITLE
Renders a different vhost config for Apache 2.4

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,9 @@ platforms:
 - name: ubuntu-14.04
   run_list:
     - recipe[apt]
+  attributes:
+    apache:
+      mpm: event        # ugly workaround for onehealth-cookbooks/apache2 #236
 - name: debian-7.4
   run_list:
     - recipe[apt]

--- a/templates/default/rgw.conf.erb
+++ b/templates/default/rgw.conf.erb
@@ -25,9 +25,13 @@ LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{Use
       Options +ExecCGI
       AllowOverride All
       SetHandler fastcgi-script
+      AuthBasicAuthoritative Off
+      <%- if node[:apache][:version].to_f < 2.4 %>
       Order allow,deny
       Allow from all
-      AuthBasicAuthoritative Off
+      <%- else %>
+      Require all granted
+      <%- end %>
     </Directory>
   </IfModule>
 


### PR DESCRIPTION
Fixes Ubuntu 14.04 with Apache 2.4 by outputting different access control options based on what version of Apache has been installed by Chef.
Because this file is explicitly installed by the web_app lwrp, the apache version node attribute can be relied on to exist.

Ran the test kitchen for aio-debian-74, aio-ubuntu-1204, and aio-ubuntu-1404 and they all work.
