### PR TITLE
Improves cephfs fuse detection in the cephfs recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Ceph Rados Gateway nodes should use the ceph-radosgw role
 
 * node['ceph']['config']['mds'] - a hash of settings to save in ceph.conf in the [mds] section, such as `'mds cache size' => '100000'`
 * node['ceph']['cephfs_mount'] - where the cephfs recipe should mount CephFS
+* node['ceph']['cephfs_use_fuse'] - whether the cephfs recipe should use the fuse cephfs client. It will default to heuristics based on the kernel version
 
 ### Ceph Rados Gateway
 

--- a/attributes/cephfs.rb
+++ b/attributes/cephfs.rb
@@ -1,4 +1,5 @@
 default['ceph']['cephfs_mount'] = '/ceph'
+default['ceph']['cephfs_use_fuse'] = nil  # whether the recipe's fuse mount uses cephfs-fuse instead of kernel client, defaults to heuristics
 
 case node['platform_family']
 when 'debian'

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -12,3 +12,24 @@ def debug_ext
     ''
   end
 end
+
+def cephfs_requires_fuse
+  # What kernel version supports the given Ceph version tunables
+  # http://ceph.com/docs/master/rados/operations/crush-map/
+  min_versions = {
+    'argonaut' => 3.6,
+    'bobtail' => 3.9,
+    'cuttlefish' => 3.9,
+    'dumpling' => 3.9,
+    'emperor' => 3.9,
+    'firefly' => 3.15
+  }
+  min_versions.default = 3.15
+
+  # If we are on linux and have a new-enough kernel, allow kernel mount
+  if node['os'] == 'linux' && Gem::Version.new(node['kernel']['release'].to_f) >= Gem::Version.new(min_versions[node['ceph']['version']])
+    false
+  else
+    true
+  end
+end

--- a/recipes/cephfs.rb
+++ b/recipes/cephfs.rb
@@ -17,21 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requires_fuse =
-  case node['platform']
-  when 'debian'
-    node['platform_version'].to_f < 7.0
-  when 'ubuntu'
-    node['platform_version'].to_f < 12.04
-  when 'redhat'
-    node['platform_version'].to_f < 7.0
-  when 'fedora'
-    node['platform_version'].to_f < 17.0
-  else
-    true
-end
-
 ceph_cephfs node['ceph']['cephfs_mount'] do
-  use_fuse requires_fuse
+  use_fuse node['ceph']['cephfs_use_fuse'] || cephfs_requires_fuse
   action [:mount, :enable]
 end

--- a/test/cookbooks/ceph_test/recipes/cephfs.rb
+++ b/test/cookbooks/ceph_test/recipes/cephfs.rb
@@ -17,22 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requires_fuse =
-  case node['platform']
-  when 'debian'
-    node['platform_version'].to_f < 7.0
-  when 'ubuntu'
-    node['platform_version'].to_f < 12.04
-  when 'redhat'
-    node['platform_version'].to_f < 7.0
-  when 'fedora'
-    node['platform_version'].to_f < 17.0
-  else
-    true
-end
-
 ceph_cephfs '/ceph' do
-  use_fuse requires_fuse
+  use_fuse cephfs_requires_fuse
   action [:mount, :enable]
 end
 ceph_cephfs '/ceph.fuse' do
@@ -48,7 +34,7 @@ file '/ceph/subdir/file' do
   content "It works\n"
 end
 
-unless requires_fuse
+unless cephfs_requires_fuse
   ceph_cephfs '/subceph' do
     use_fuse false
     cephfs_subdir '/subdir'

--- a/test/integration/aio/bats/ceph-running.bats
+++ b/test/integration/aio/bats/ceph-running.bats
@@ -7,7 +7,7 @@
 }
 
 @test "cephfs is mounted" {
-  mount | grep 'type ceph'
+  mount | grep -E 'type (fuse\.)?ceph'
 }
 
 @test "radosgw is running" {


### PR DESCRIPTION
Explicitly checks for Linux kernel version
Adds an option to override and explicitly force kernel or fuse mode

Fixes #160
