### PR TITLE
Describes how to use a wrapper cookbook for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ The other set of attributes that this recipe needs is node['ceph']['osd_devices'
 * {'device' => '/dev/sde', 'dmcrypt' => true} - Store the data encrypted by passing --dmcrypt to `ceph-disk-prepare`
 * {'device' => '/dev/sdc', 'journal' => '/dev/sdd2'} - use a full disk for the OSD with a custom partition for the journal
 
+### Using a Policy Wrapper Cookbook
+
+To automate setting several of these node attributes, it is recommended to use a policy wrapper cookbook. This allows the ability to use Chef Server cookbook versions along with environment version restrictions to roll out configuration changes in an ordered fashion.
+
+It also can help with automating some settings. For example, a wrapper cookbook could peek at the list of harddrives that ohai has found and populate node['ceph']['osd_devices'] accordingly, instead of manually typing them all in:
+
+```ruby
+node.override['ceph']['osd_devices'] = node['block_device'].each.reject{ |name, data| name !~ /^sd[b-z]/}.sort.map { |name, data| {'journal' => "/dev/#{name}"} }
+```
+
+For best results, the wrapper cookbook's recipe should be placed before the Ceph cookbook in the node's runlist. This will ensure that any attributes are in place before the Ceph cookbook runs and consumes those attributes.
+
 ### Ceph Monitor
 
 Ceph monitor nodes should use the ceph-mon role.


### PR DESCRIPTION
This provides an example of how to use a wrapper cookbook, which is how Chef prefers organizational settings to be configured.

This will accomplish the goal of #56 in an extensible way.