### PR TITLE
Fixes cephfs with fuse on successive runs

### DIFF
--- a/providers/cephfs.rb
+++ b/providers/cephfs.rb
@@ -29,6 +29,7 @@ def manage_mount(directory, subdir, use_fuse, action)
       dump 0
       pass 0
       action action
+      not_if "mount | grep \"^ceph-fuse on #{Regexp.escape(directory)}\"" if action == :mount
     end
   else
     mons = mon_addresses.join(',') + ':' + subdir


### PR DESCRIPTION
The fstab and stuff need the weird option string as the 'device'
But the mount command shows 'ceph-fuse' as the device
Chef sees that they are different and tries to mount again
This adds a workaround to detect that it's already mounted
