### PR TITLE
Added zap_disk option

### DIFF
--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -111,7 +111,7 @@ else
       end
 
       dmcrypt = osd_device['encrypted'] == true ? '--dmcrypt' : ''
-      zap_disk = (osd_device['status'].eq? "zap-disk") ? '--zap-disk' : ''
+      zap_disk = (osd_device['status'].eq? 'zap-disk') ? '--zap-disk' : ''
 
       execute "ceph-disk-prepare on #{osd_device['device']}" do
         command "ceph-disk-prepare #{dmcrypt} #{zap_disk} #{osd_device['device']} #{osd_device['journal']}"


### PR DESCRIPTION
This change adds an attribute that enables the OSD disks to be zapped before activation. This is handy for HW that has already been formatted before use with Ceph, and requires a wipe before use with Ceph. 

Also, this is my first commit to Ceph, so let me know if I did something inconsistent with the Ceph community contribution guidelines.
