### PR TITLE
Fixes a rubocop warning

### DIFF
--- a/templates/default/rgw.conf.erb
+++ b/templates/default/rgw.conf.erb
@@ -26,7 +26,7 @@ LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{Use
       AllowOverride All
       SetHandler fastcgi-script
       AuthBasicAuthoritative Off
-      <%- if node[:apache][:version].to_f < 2.4 %>
+      <%- if node['apache']['version'].to_f < 2.4 %>
       Order allow,deny
       Allow from all
       <%- else %>


### PR DESCRIPTION
The rest of the cookbook uses strings instead of hashes for attribute names, and rubocopy complained