### PR TITLE
Fix centos6 installation

### DIFF
--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -23,6 +23,10 @@ include_recipe 'ceph::_common'
 include_recipe 'ceph::radosgw_install'
 include_recipe 'ceph::conf'
 
+if node['ceph']['radosgw']['webserver_companion']
+  include_recipe "ceph::radosgw_#{node['ceph']['radosgw']['webserver_companion']}"
+end
+
 directory '/var/log/radosgw' do
   owner node['apache']['user']
   group node['apache']['group']
@@ -40,10 +44,6 @@ directory '/var/run/ceph-radosgw' do
   group node['apache']['group']
   mode '0755'
   action :create
-end
-
-if node['ceph']['radosgw']['webserver_companion']
-  include_recipe "ceph::radosgw_#{node['ceph']['radosgw']['webserver_companion']}"
 end
 
 ceph_client 'radosgw' do

--- a/recipes/rpm.rb
+++ b/recipes/rpm.rb
@@ -10,14 +10,18 @@ if branch == 'dev' && platform_family != 'centos' && platform_family != 'fedora'
   fail "Dev branch for #{platform_family} is not yet supported"
 end
 
+package 'yum-priorities'
+
 yum_repository 'ceph' do
   baseurl node['ceph'][platform_family][branch]['repository']
   gpgkey node['ceph'][platform_family][branch]['repository_key']
+  priority '10'
 end
 
 yum_repository 'ceph-extra' do
   baseurl node['ceph'][platform_family]['extras']['repository']
   gpgkey node['ceph'][platform_family]['extras']['repository_key']
+  priority '10'
   only_if { node['ceph']['extras_repo'] }
 end
 


### PR DESCRIPTION
Centos6 epel has a higher version number than ceph's official repo, but has some bugs. This fixes them.
To get it to work, the Radosgw Apache installation order needed to be changed.

This appears to fix #148.