### PR TITLE
Moved _common to default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Ceph monitor nodes should use the ceph-mon role.
 Includes:
 
 * ceph::default
-* ceph::conf
 
 ### Ceph Metadata Server
 
@@ -84,7 +83,6 @@ Ceph OSD nodes should use the ceph-osd role
 Includes:
 
 * ceph::default
-* ceph::conf
 
 ### Ceph Rados Gateway
 

--- a/recipes/_common_install.rb
+++ b/recipes/_common_install.rb
@@ -1,1 +1,0 @@
-include_recipe 'ceph::repo' if node['ceph']['install_repo']

--- a/recipes/cephfs_install.rb
+++ b/recipes/cephfs_install.rb
@@ -1,4 +1,4 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 
 node['ceph']['cephfs']['packages'].each do |pck|
   package pck

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph::repo' if node['ceph']['install_repo']
+include_recipe 'ceph::conf'
 
 # Tools needed by cookbook
 node['ceph']['packages'].each do |pck|

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -17,9 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'ceph::_common'
+include_recipe 'ceph'
 include_recipe 'ceph::mds_install'
-include_recipe 'ceph::conf'
 
 cluster = 'ceph'
 

--- a/recipes/mds_install.rb
+++ b/recipes/mds_install.rb
@@ -1,4 +1,4 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 
 node['ceph']['mds']['packages'].each do |pck|
   package pck

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -16,9 +16,8 @@
 
 node.default['ceph']['is_mon'] = true
 
-include_recipe 'ceph::_common'
+include_recipe 'ceph'
 include_recipe 'ceph::mon_install'
-include_recipe 'ceph::conf'
 
 service_type = node['ceph']['mon']['init_style']
 

--- a/recipes/mon_install.rb
+++ b/recipes/mon_install.rb
@@ -1,4 +1,4 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 
 node['ceph']['mon']['packages'].each do |pck|
   package pck

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -31,9 +31,8 @@
 #   }
 # ]
 
-include_recipe 'ceph::_common'
+include_recipe 'ceph'
 include_recipe 'ceph::osd_install'
-include_recipe 'ceph::conf'
 
 package 'gdisk' do
   action :upgrade

--- a/recipes/osd_install.rb
+++ b/recipes/osd_install.rb
@@ -1,4 +1,4 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 
 node['ceph']['osd']['packages'].each do |pck|
   package pck

--- a/recipes/radosgw.rb
+++ b/recipes/radosgw.rb
@@ -19,9 +19,8 @@
 
 node.default['ceph']['is_radosgw'] = true
 
-include_recipe 'ceph::_common'
+include_recipe 'ceph'
 include_recipe 'ceph::radosgw_install'
-include_recipe 'ceph::conf'
 
 directory '/var/log/radosgw' do
   owner node['apache']['user']

--- a/recipes/radosgw_apache2.rb
+++ b/recipes/radosgw_apache2.rb
@@ -41,8 +41,7 @@
 #   end
 # end
 
-include_recipe 'ceph::_common'
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 include_recipe 'ceph::radosgw_apache2_repo'
 
 node['ceph']['radosgw']['apache2']['packages'].each do |pck|

--- a/recipes/radosgw_install.rb
+++ b/recipes/radosgw_install.rb
@@ -1,4 +1,4 @@
-include_recipe 'ceph::_common_install'
+include_recipe 'ceph'
 
 node['ceph']['radosgw']['packages'].each do |pck|
   package pck

--- a/resources/cephfs.rb
+++ b/resources/cephfs.rb
@@ -8,7 +8,6 @@ attribute :cephfs_subdir, :kind_of => String, :default => '/'
 def initialize(*args)
   super
   @action = :mount
-  @run_context.include_recipe 'ceph::_common'
+  @run_context.include_recipe 'ceph'
   @run_context.include_recipe 'ceph::cephfs_install'
-  @run_context.include_recipe 'ceph::conf'
 end


### PR DESCRIPTION
Moving _common.rb to default.rb makes this cookbook easier to include
in other cookbooks.  This also brings this cookbook back in line
with its README.