### PR TITLE
Sets the default version to giant

### DIFF
--- a/attributes/mds.rb
+++ b/attributes/mds.rb
@@ -1,7 +1,7 @@
 include_attribute 'ceph'
 
 default['ceph']['mds']['init_style'] = node['init_style']
-default['ceph']['mds']['fs']['ceph'] = {'data_pool' => 'data', 'metadata_pool' => 'metadata'}
+default['ceph']['mds']['fs']['ceph'] = { 'data_pool' => 'data', 'metadata_pool' => 'metadata' }
 
 case node['platform_family']
 when 'debian'

--- a/attributes/mds.rb
+++ b/attributes/mds.rb
@@ -1,6 +1,7 @@
 include_attribute 'ceph'
 
 default['ceph']['mds']['init_style'] = node['init_style']
+default['ceph']['mds']['fs']['ceph'] = {'data_pool' => 'data', 'metadata_pool' => 'metadata'}
 
 case node['platform_family']
 when 'debian'

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -1,6 +1,6 @@
 default['ceph']['branch'] = 'stable' # Can be stable, testing or dev.
 # Major release version to install or gitbuilder branch
-default['ceph']['version'] = 'firefly'
+default['ceph']['version'] = 'giant'
 default['ceph']['el_add_epel'] = true
 default['ceph']['repo_url'] = 'http://ceph.com'
 default['ceph']['extras_repo_url'] = 'http://ceph.com/packages/ceph-extras'

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -10,33 +10,33 @@ case node['platform_family']
 when 'debian'
   # Debian/Ubuntu default repositories
   default['ceph']['debian']['stable']['repository'] = "#{node['ceph']['repo_url']}/debian-#{node['ceph']['version']}/"
-  default['ceph']['debian']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['stable']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['debian']['testing']['repository'] = "#{node['ceph']['repo_url']}/debian-testing/"
-  default['ceph']['debian']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['testing']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['debian']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-deb-#{node['lsb']['codename']}-x86_64-basic/ref/#{node['ceph']['version']}"
   default['ceph']['debian']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
   default['ceph']['debian']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/debian/"
-  default['ceph']['debian']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['extras']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
 when 'rhel'
   # Redhat/CentOS default repositories
   default['ceph']['rhel']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/el6/x86_64/"
-  default['ceph']['rhel']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['stable']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['rhel']['testing']['repository'] = "#{node['ceph']['repo_url']}/rpm-testing/el6/x86_64/"
-  default['ceph']['rhel']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['testing']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['rhel']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-rpm-centos6-x86_64-basic/ref/#{node['ceph']['version']}/x86_64/"
   default['ceph']['rhel']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
   default['ceph']['rhel']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/rpm/rhel6/x86_64/"
-  default['ceph']['rhel']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['extras']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
 when 'fedora'
   # Fedora default repositories
   default['ceph']['fedora']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/fc#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['stable']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['fedora']['testing']['repository'] = "#{node['ceph']['repo_url']}/rpm-testing/fc#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['testing']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
   default['ceph']['fedora']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-rpm-fc#{node['platform_version']}-x86_64-basic/ref/#{node['ceph']['version']}/RPMS/x86_64/"
   default['ceph']['fedora']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
   default['ceph']['fedora']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/rpm/fedora#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['extras']['repository_key'] = 'https://raw.githubusercontent.com/ceph/ceph/master/keys/release.asc'
 when 'suse'
   # (Open)SuSE default repositories
   # Chef doesn't make a difference between suse and opensuse

--- a/providers/cephfs.rb
+++ b/providers/cephfs.rb
@@ -29,6 +29,7 @@ def manage_mount(directory, subdir, use_fuse, action)
       dump 0
       pass 0
       action action
+      not_if "mount | grep \"^ceph-fuse on #{Regexp.escape(directory)}\"" if action == :mount
     end
   else
     mons = mon_addresses.sort.join(',') + ':' + subdir

--- a/recipes/mds.rb
+++ b/recipes/mds.rb
@@ -22,6 +22,26 @@ include_recipe 'ceph::mds_install'
 
 cluster = 'ceph'
 
+if node['ceph']['version'] >= 'giant'
+  # doesn't work on non-mon nodes, will need to be moved to lwrp
+  node['ceph']['mds']['fs'].keys.each do |fs|
+    metadata_pool = node['ceph']['mds']['fs'][fs]['metadata_pool']
+    data_pool = node['ceph']['mds']['fs'][fs]['data_pool']
+
+    [metadata_pool, data_pool].each do |pool_name|
+      execute "ensure ceph pool #{pool_name} exists" do
+        command "ceph osd pool create #{pool_name} 32"
+        not_if "rados lspools | grep '^#{Regexp.quote(pool_name)}$'"
+      end
+    end
+
+    execute "ensure cephfs #{fs} exists" do
+      command "ceph fs new #{fs} #{metadata_pool} #{data_pool}"
+      not_if "ceph fs ls | grep '^#{Regexp.quote(fs)}$'"
+    end
+  end
+end
+
 directory "/var/lib/ceph/mds/#{cluster}-#{node['hostname']}" do
   owner 'root'
   group 'root'


### PR DESCRIPTION
A few months ago, I created this branch to cherry-pick the different PRs (from @hufman and @klamontagne) that I have found useful to make this cookbook work with Ceph "giant" release.

After merging current master (as of version 0.8.0) into it, the difference between the branches became so tiny that I think it a merge into master could be considered.
