### PR TITLE
Update supported codenames in radosgw_apache2_repo

### DIFF
--- a/recipes/radosgw_apache2_repo.rb
+++ b/recipes/radosgw_apache2_repo.rb
@@ -1,6 +1,6 @@
 if node['ceph']['radosgw']['use_apache_fork'] == true
   if node.platform_family?('debian') &&
-    %w(precise quantal raring squeeze wheezy).include?(node['lsb']['codename'])
+    %w(precise quantal raring saucy squeeze trusty wheezy).include?(node['lsb']['codename'])
     apt_repository 'ceph-apache2' do
       repo_name 'ceph-apache2'
       uri "http://gitbuilder.ceph.com/apache2-deb-#{node['lsb']['codename']}-x86_64-basic/ref/master"


### PR DESCRIPTION
Update `ceph::radosgw_apache2_repo` to add repositories for Ubuntu Saucy and Trusty. (Utopic and the upcoming Vivid have no official repositories yet.)