### PR TITLE
change from package name to glob for regex support

### DIFF
--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -10,7 +10,7 @@ else node['lsb']['codename']
 end
 
 apt_preference 'ceph_repo' do
-  package_name '*'
+  glob '*'
   pin 'origin "ceph.com"'
   pin_priority '1001'
 end


### PR DESCRIPTION
This comes from a recent change in the apt cookbook.

https://github.com/opscode-cookbooks/apt/commit/d9da7847c58d156ad1e24021d49511efdce0394d

This has some comments as to why glob should be used vs package_name.