### PR TITLE
Get OSD bootstrap key on the current node if possible

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -39,6 +39,8 @@ def osd_secret
   if node['ceph']['encrypted_data_bags']
     secret = Chef::EncryptedDataBagItem.load_secret(node['ceph']['osd']['secret_file'])
     return Chef::EncryptedDataBagItem.load('ceph', 'osd', secret)['secret']
+  elsif node['ceph']['bootstrap_osd_key']
+    return node['ceph']['bootstrap_osd_key']
   else
     return mon_nodes[0]['ceph']['bootstrap_osd_key']
   end


### PR DESCRIPTION
When deploying monitor and OSD daemons on the same node, it is
possible to retrieve the OSD bootstrap key from the node itself
(if the monitor recipe has already been applied), instead of
relying on a search in Chef for existing monitors.

This change also serves as a workaround when monitor and OSD
daemons are being installed on the first node of the cluster and,
for some reason, chef-client doesn't converge at the first attempt.
Without this change, running chef-client a second time, the node
might not be found with the Chef search.