### PR TITLE
Pool LWRP and auto create user-defined pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Ceph Rados Gateway nodes should use the ceph-radosgw role
 * `node['ceph']['config']['global']['cluster network']` - a CIDR specification of a separate cluster replication network
 * `node['ceph']['config']['config-sections']` - add to this hash to add extra config sections to the ceph.conf
 
+* `node['ceph']['user_pools']` - an array of pool definitions, with attributes `name`, `pg_num` and `create_options` (optional), that are automatically created when a monitor is deployed
+
 ### Ceph MON
 
 * `node['ceph']['config']['mon']` - a hash of settings to save in ceph.conf in the [mon] section, such as `'mon osd nearfull ratio' => '0.70'`
@@ -166,6 +168,24 @@ The ceph\_cephfs LWRP provides an easy way to mount CephFS. It will automaticall
 - :directory - name attribute. Where to mount CephFS in the local filesystem
 - :use\_fuse - whether to use ceph-fuse or the kernel client to mount the filesystem. ceph-fuse is updated more often, but the kernel client allows for subdirectory mounting. Defaults to true
 - :cephfs\_subdir - which CephFS subdirectory to mount. Defaults to '/'. An exception will be thrown if this option is set to anything other than '/' if use\_fuse is also true
+
+### ceph\_pool
+
+The ceph\_pool LWRP provides an easy way to create and delete Ceph pools.
+
+It assumes that connectivity to the cluster is setup and that admin credentials are available from default locations, e.g. /etc/ceph/ceph.client.admin.keyring.
+
+#### Actions
+
+- :add - creates a pool with the given number of placement groups
+- :delete - deletes an existing pool
+
+#### Parameters
+
+- :name - the name of the pool to create or delete
+- :pg_num - number of placement groups, when creating a new pool
+- :create_options - arguments for pool creation (optional)
+- :force - force the deletion of an exiting pool along with any data that is stored in it
 
 ## DEVELOPING
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,8 @@ default['ceph']['encrypted_data_bags'] = false
 
 default['ceph']['install_repo'] = true
 
+default['ceph']['user_pools'] = []
+
 case node['platform']
 when 'ubuntu'
   default['ceph']['init_style'] = 'upstart'

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -1,0 +1,68 @@
+#
+# Cookbook Name:: ceph
+# Provider:: pool
+#
+# Author:: Sergio de Carvalho <scarvalhojr@users.noreply.github.com>
+#
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :create do
+  if @current_resource.exists
+    Chef::Log.info "#{ @new_resource } already exists - nothing to do."
+  else
+    converge_by("Creating #{ @new_resource }") do
+      create_pool
+    end
+  end
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Deleting #{ @new_resource }") do
+      delete_pool
+    end
+  else
+    Chef::Log.info "#{ @current_resource } does not exist - nothing to do."
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::CephPool.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  @current_resource.exists = pool_exists?(@current_resource.name)
+end
+
+def create_pool
+  cmd_text = "ceph osd pool create #{new_resource.name} #{new_resource.pg_num}"
+  cmd_text << " #{new_resource.create_options}" if new_resource.create_options
+  cmd = Mixlib::ShellOut.new(cmd_text)
+  cmd.run_command
+  cmd.error!
+  Chef::Log.debug "Pool created: #{ cmd.stderr }"
+end
+
+def delete_pool
+  cmd_text = "ceph osd pool delete #{new_resource.name}"
+  cmd_text << " #{new_resource.name} --yes-i-really-really-mean-it" if
+    new_resource.force
+  cmd = Mixlib::ShellOut.new(cmd_text)
+  cmd.run_command
+  cmd.error!
+  Chef::Log.debug "Pool deleted: #{ cmd.stderr }"
+end
+
+def pool_exists?(name)
+  cmd = Mixlib::ShellOut.new("ceph osd pool get #{name} size")
+  cmd.run_command
+  cmd.error!
+  Chef::Log.debug "Pool exists: #{ cmd.stdout }"
+  true
+rescue
+  Chef::Log.debug "Pool doesn't seem to exist: #{ cmd.stderr }"
+  false
+end

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -125,3 +125,13 @@ if use_cephx? && !node['ceph']['encrypted_data_bags']
     not_if { node['ceph']['bootstrap_osd_key'] }
   end
 end
+
+if node['ceph']['user_pools']
+  # Create user-defined pools
+  node['ceph']['user_pools'].each do |pool|
+    ceph_pool pool['name'] do
+      pg_num pool['pg_num']
+      create_options pool['create_options'] if pool['create_options']
+    end
+  end
+end

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: ceph
+# Resource:: pool
+#
+# Author:: Sergio de Carvalho <scarvalhojr@users.noreply.github.com>
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :name, :kind_of => String, :name_attribute => true
+
+# The total number of placement groups for the pool.
+attribute :pg_num, :kind_of => Integer, :required => true
+
+# Optional arguments for pool creation
+attribute :create_options, :kind_of => String
+
+# Forces a non-empty pool to be deleted.
+attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
+
+attr_accessor :exists


### PR DESCRIPTION
This change introduces a pool LWRP that allows Ceph user pools to be
created and/or deleted by simply specifying their name and number of
placement groups.

It also allows users to define their own pools in Chef attributes or
environments that are then created automatically when nodes are
provisioned.