### PR TITLE
Flag sensitive execute and file resources

### DIFF
--- a/providers/client.rb
+++ b/providers/client.rb
@@ -33,12 +33,12 @@ action :add do
   key = @new_resource.key || get_key(keyname)
 
   # update the key in the file
-  file filename do
+  file filename do # ~FC009
     content file_content(keyname, key, as_keyring)
     owner owner
     group group
     mode mode
-    # sensitive true if Chef::Resource::File.method_defined? :sensitive # ~FC009
+    sensitive true if Chef::Resource::File.method_defined? :sensitive
   end
 
 end
@@ -112,8 +112,8 @@ def create_entity(keyname)
   Chef::Log.debug "Client #{keyname} created"
 
   # remove temporary keyring file
-  file tmp_keyring do
+  file tmp_keyring do # ~FC009
     action :delete
-    # sensitive true if Chef::Resource::File.method_defined? :sensitive # ~FC009
+    sensitive true if Chef::Resource::File.method_defined? :sensitive
   end
 end

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -42,17 +42,19 @@ cluster = 'ceph'
 
 keyring = "#{Chef::Config[:file_cache_path]}/#{cluster}-#{node['hostname']}.mon.keyring"
 
-execute 'format mon-secret as keyring' do
+execute 'format mon-secret as keyring' do # ~FC009
   command lazy { "ceph-authtool '#{keyring}' --create-keyring --name=mon. --add-key='#{mon_secret}' --cap mon 'allow *'" }
   creates keyring
   only_if { mon_secret }
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
-execute 'generate mon-secret as keyring' do
+execute 'generate mon-secret as keyring' do # ~FC009
   command "ceph-authtool '#{keyring}' --create-keyring --name=mon. --gen-key --cap mon 'allow *'"
   creates keyring
   not_if { mon_secret }
   notifies :create, 'ruby_block[save mon_secret]', :immediately
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
 ruby_block 'save mon_secret' do

--- a/recipes/osd.rb
+++ b/recipes/osd.rb
@@ -54,10 +54,11 @@ end
 # TODO: cluster name
 cluster = 'ceph'
 
-execute 'format bootstrap-osd as keyring' do
+execute 'format bootstrap-osd as keyring' do # ~FC009
   command lazy { "ceph-authtool '/var/lib/ceph/bootstrap-osd/#{cluster}.keyring' --create-keyring --name=client.bootstrap-osd --add-key='#{osd_secret}'" }
   creates "/var/lib/ceph/bootstrap-osd/#{cluster}.keyring"
   only_if { osd_secret }
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end
 
 if crowbar?


### PR DESCRIPTION
Use sensitive attribute on execute and file resources that may expose
sensitive data. This avoids keys and secrets appearing on chef-client
logs.