### PR TITLE
Add bootstrap-osd key after it's been created if databags are not used

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -55,11 +55,6 @@ execute 'generate mon-secret as keyring' do
   notifies :create, 'ruby_block[save mon_secret]', :immediately
 end
 
-execute 'add bootstrap-osd key to keyring' do
-  command lazy { "ceph-authtool '#{keyring}' --name=client.bootstrap-osd --add-key='#{osd_secret}' --cap mon 'allow profile bootstrap-osd'  --cap osd 'allow profile bootstrap-osd'" }
-  only_if { osd_secret }
-end
-
 ruby_block 'save mon_secret' do
   block do
     fetch = Mixlib::ShellOut.new("ceph-authtool '#{keyring}' --print-key --name=mon.")
@@ -129,6 +124,11 @@ if use_cephx? && !node['ceph']['encrypted_data_bags']
     end
     not_if { node['ceph']['bootstrap_osd_key'] }
   end
+end
+
+execute 'add bootstrap-osd key to keyring' do
+  command lazy { "ceph-authtool '#{keyring}' --name=client.bootstrap-osd --add-key='#{osd_secret}' --cap mon 'allow profile bootstrap-osd'  --cap osd 'allow profile bootstrap-osd'" }
+  only_if { osd_secret }
 end
 
 if node['ceph']['user_pools']


### PR DESCRIPTION
This change fixes a regression introduced 807f08 that caused
the cookbook to fail if data_bags were not used. The bootstrap-osd
key would not be created at the time of the key being added to the
keyring, causing the chef run to fail. We now try to add the key after
we've checked if the key needs to be created, which will only happen
if we're not using data_bags. 