### PR TITLE
Fix timing issue with ceph pool create

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -130,13 +130,3 @@ execute 'add bootstrap-osd key to keyring' do
   command lazy { "ceph-authtool '#{keyring}' --name=client.bootstrap-osd --add-key='#{osd_secret}' --cap mon 'allow profile bootstrap-osd'  --cap osd 'allow profile bootstrap-osd'" }
   only_if { osd_secret }
 end
-
-if node['ceph']['user_pools']
-  # Create user-defined pools
-  node['ceph']['user_pools'].each do |pool|
-    ceph_pool pool['name'] do
-      pg_num pool['pg_num']
-      create_options pool['create_options'] if pool['create_options']
-    end
-  end
-end

--- a/recipes/pools.rb
+++ b/recipes/pools.rb
@@ -1,0 +1,19 @@
+# Author:: mick-m <mick-m@users.noreply.github.com>
+# Cookbook Name:: ceph
+# Recipe:: pools
+#
+# Copyright 2015, Workday
+#
+# This recipe creates user-defined Ceph pools defined in the Chef environment.
+# Having this code in a separate recipe allows better control of when the pools
+# are created.
+
+if node['ceph']['user_pools']
+  node['ceph']['user_pools'].each do |pool|
+    # Create user-defined pools
+    ceph_pool pool['name'] do
+      pg_num pool['pg_num']
+      create_options pool['create_options'] if pool['create_options']
+    end
+  end
+end

--- a/roles/ceph-mon.json
+++ b/roles/ceph-mon.json
@@ -4,6 +4,7 @@
   "description": "Ceph Monitor",
   "run_list": [
     "recipe[ceph::repo]",
-    "recipe[ceph::mon]"
+    "recipe[ceph::mon]",
+    "recipe[ceph:pools]
   ]
 }


### PR DESCRIPTION
There are scenarios being encountered where ceph::mon attempts to create
pools before all the required ceph services are up and running. This
causes the recipe to fail.

My proposed solution to this issue is to remove the 'ceph pool create'
block from the ceph::mon recipe and place it in it's own separate recipe
(ceph::pools), which is placed below ceph::mon in the runlist for the role
(ceph-mon.json).

Having this code in a separate recipe allows better control of when the
pools are created.