### PR TITLE
changed default paths for package download and release.asc

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -3,7 +3,7 @@ default['ceph']['branch'] = 'stable' # Can be stable, testing or dev.
 default['ceph']['version'] = 'firefly'
 default['ceph']['el_add_epel'] = true
 default['ceph']['repo_url'] = 'http://download.ceph.com'
-default['ceph']['extras_repo_url'] = 'http://ceph.com/packages/ceph-extras' #GONE is no longer available on this server 
+default['ceph']['extras_repo_url'] = 'http://ceph.com/packages/ceph-extras'
 default['ceph']['extras_repo'] = false
 
 case node['platform_family']

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -2,41 +2,41 @@ default['ceph']['branch'] = 'stable' # Can be stable, testing or dev.
 # Major release version to install or gitbuilder branch
 default['ceph']['version'] = 'firefly'
 default['ceph']['el_add_epel'] = true
-default['ceph']['repo_url'] = 'http://ceph.com'
-default['ceph']['extras_repo_url'] = 'http://ceph.com/packages/ceph-extras'
+default['ceph']['repo_url'] = 'http://download.ceph.com'
+default['ceph']['extras_repo_url'] = 'http://ceph.com/packages/ceph-extras' #GONE is no longer available on this server 
 default['ceph']['extras_repo'] = false
 
 case node['platform_family']
 when 'debian'
   # Debian/Ubuntu default repositories
   default['ceph']['debian']['stable']['repository'] = "#{node['ceph']['repo_url']}/debian-#{node['ceph']['version']}/"
-  default['ceph']['debian']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['stable']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['debian']['testing']['repository'] = "#{node['ceph']['repo_url']}/debian-testing/"
-  default['ceph']['debian']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['testing']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['debian']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-deb-#{node['lsb']['codename']}-x86_64-basic/ref/#{node['ceph']['version']}"
-  default['ceph']['debian']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
+  default['ceph']['debian']['dev']['repository_key'] = "#{node['ceph']['extras_repo_url']}/keys/autobuild.asc"
   default['ceph']['debian']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/debian/"
-  default['ceph']['debian']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['debian']['extras']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
 when 'rhel'
   # Redhat/CentOS default repositories
   default['ceph']['rhel']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/el6/x86_64/"
-  default['ceph']['rhel']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['stable']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['rhel']['testing']['repository'] = "#{node['ceph']['repo_url']}/rpm-testing/el6/x86_64/"
-  default['ceph']['rhel']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['testing']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['rhel']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-rpm-centos6-x86_64-basic/ref/#{node['ceph']['version']}/x86_64/"
-  default['ceph']['rhel']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
+  default['ceph']['rhel']['dev']['repository_key'] = "#{node['ceph']['repo_url']}/keys/autobuild.asc"
   default['ceph']['rhel']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/rpm/rhel6/x86_64/"
-  default['ceph']['rhel']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['rhel']['extras']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
 when 'fedora'
   # Fedora default repositories
   default['ceph']['fedora']['stable']['repository'] = "#{node['ceph']['repo_url']}/rpm-#{node['ceph']['version']}/fc#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['stable']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['stable']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['fedora']['testing']['repository'] = "#{node['ceph']['repo_url']}/rpm-testing/fc#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['testing']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['testing']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
   default['ceph']['fedora']['dev']['repository'] = "http://gitbuilder.ceph.com/ceph-rpm-fc#{node['platform_version']}-x86_64-basic/ref/#{node['ceph']['version']}/RPMS/x86_64/"
-  default['ceph']['fedora']['dev']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
+  default['ceph']['fedora']['dev']['repository_key'] = "#{node['ceph']['repo_url']}/keys/autobuild.asc"
   default['ceph']['fedora']['extras']['repository'] = "#{node['ceph']['extras_repo_url']}/rpm/fedora#{node['platform_version']}/x86_64/"
-  default['ceph']['fedora']['extras']['repository_key'] = 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc'
+  default['ceph']['fedora']['extras']['repository_key'] = "#{node['ceph']['repo_url']}/keys/release.asc"
 when 'suse'
   # (Open)SuSE default repositories
   # Chef doesn't make a difference between suse and opensuse


### PR DESCRIPTION
http://ceph.com is very often in maintenance.
I think it would be better to use http://download.ceph.com instead.

I testet the changes with ubuntu14.04
