### PR TITLE
Add timeout to ceph_pool resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,11 +22,11 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
-  Enabled: false
 WordArray:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/PerceivedComplexity:
+  Enabled: false
+ConditionalAssignment:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache: bundler
 bundler_args: --without kitchen_common kitchen_vagrant
 rvm:
-  - 2.0
   - 2.1
   - 2.2
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 4.0'
-  gem 'rubocop', '~> 0.33'
+  gem 'rubocop', '~> 0.40.0'
 end
 
 group :unit do

--- a/providers/client.rb
+++ b/providers/client.rb
@@ -53,7 +53,7 @@ def load_current_resource
   @current_resource.key(get_key(@current_resource.keyname))
   @current_resource.caps_match = @current_resource.caps == @new_resource.caps
   @current_resource.keys_match = @new_resource.key.nil? || (@current_resource.key == @new_resource.key)
-  @current_resource.exists = ! (@current_resource.key.nil? || @current_resource.key.empty?)
+  @current_resource.exists = !(@current_resource.key.nil? || @current_resource.key.empty?)
 end
 
 def file_content(keyname, key, as_keyring)

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -40,7 +40,7 @@ end
 def create_pool
   cmd_text = "ceph osd pool create #{new_resource.name} #{new_resource.pg_num}"
   cmd_text << " #{new_resource.create_options}" if new_resource.create_options
-  cmd = Mixlib::ShellOut.new(cmd_text)
+  cmd = Mixlib::ShellOut.new(cmd_text, :timeout => new_resource.timeout)
   cmd.run_command
   cmd.error!
   Chef::Log.debug "Pool created: #{cmd.stderr}"

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -51,7 +51,7 @@ def delete_pool
   cmd_text = "ceph osd pool delete #{new_resource.name}"
   cmd_text << " #{new_resource.name} --yes-i-really-really-mean-it" if
     new_resource.force
-  cmd = Mixlib::ShellOut.new(cmd_text)
+  cmd = Mixlib::ShellOut.new(cmd_text, :timeout => new_resource.timeout)
   cmd.run_command
   cmd.error!
   Chef::Log.debug "Pool deleted: #{cmd.stderr}"

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -34,6 +34,7 @@ end
 def load_current_resource
   @current_resource = Chef::Resource::CephPool.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
+  @current_resource.timeout(@new_resource.timeout)
   @current_resource.exists = pool_exists?(@current_resource.name)
 end
 
@@ -57,7 +58,7 @@ def delete_pool
 end
 
 def pool_exists?(name)
-  cmd = Mixlib::ShellOut.new("ceph osd pool get #{name} size")
+  cmd = Mixlib::ShellOut.new("ceph osd pool get #{name} size", :timeout => current_resource.timeout)
   cmd.run_command
   cmd.error!
   Chef::Log.debug "Pool exists: #{cmd.stdout}"

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -4,10 +4,10 @@ include_recipe 'apt'
 branch = node['ceph']['branch']
 
 distribution_codename =
-case node['lsb']['codename']
-when 'jessie' then 'sid'
-else node['lsb']['codename']
-end
+  case node['lsb']['codename']
+  when 'jessie' then 'sid'
+  else node['lsb']['codename']
+  end
 
 apt_preference 'ceph_repo' do
   glob '*'

--- a/recipes/tgt.rb
+++ b/recipes/tgt.rb
@@ -42,10 +42,8 @@ service 'tgt' do
   if node['platform'] == 'ubuntu'
     # The ceph version of tgt does not provide an Upstart script
     provider Chef::Provider::Service::Init::Debian
-    service_name 'tgt'
-  else
-    service_name 'tgt'
   end
+  service_name 'tgt'
   supports :restart => true
   action [:enable, :start]
 end

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -16,6 +16,9 @@ attribute :pg_num, :kind_of => Integer, :required => true
 # Optional arguments for pool creation
 attribute :create_options, :kind_of => String
 
+# The number of seconds before a timeout occurs during pool creation
+attribute :timeout, :kind_of => Integer, :default => nil, :required => false
+
 # Forces a non-empty pool to be deleted.
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -17,7 +17,7 @@ attribute :pg_num, :kind_of => Integer, :required => true
 attribute :create_options, :kind_of => String
 
 # The number of seconds before a timeout occurs during pool creation
-attribute :timeout, :kind_of => Integer, :default => nil, :required => false
+attribute :timeout, :kind_of => Integer
 
 # Forces a non-empty pool to be deleted.
 attribute :force, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
In a few instances, we found ceph_pool hanging. The timeout attribute
would allow us to control how long we would like to wait before raising
an exception.
